### PR TITLE
Bump OMEZarrReader to 0.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation 'io.vertx:vertx-config-yaml:3.8.1'
     implementation 'io.vertx:vertx-micrometer-metrics:3.8.5'
     implementation 'io.micrometer:micrometer-registry-prometheus:1.3.0'
-    implementation 'org.openmicroscopy:omero-blitz:5.7.3'
+    implementation 'org.openmicroscopy:omero-blitz:5.7.4'
     implementation 'ome:OMEZarrReader:0.5.2'
     implementation 'io.prometheus.jmx:collector:0.12.0'
     implementation 'io.prometheus:simpleclient_hotspot:0.8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'io.vertx:vertx-micrometer-metrics:3.8.5'
     implementation 'io.micrometer:micrometer-registry-prometheus:1.3.0'
     implementation 'org.openmicroscopy:omero-blitz:5.7.3'
-    implementation 'ome:OMEZarrReader:0.5.1'
+    implementation 'ome:OMEZarrReader:0.5.2'
     implementation 'io.prometheus.jmx:collector:0.12.0'
     implementation 'io.prometheus:simpleclient_hotspot:0.8.0'
     implementation 'info.picocli:picocli:4.1.4'

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
 
     testImplementation("junit:junit:4.12")
     testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'com.glencoesoftware:bioformats2raw:0.9.3'
+    testImplementation 'com.glencoesoftware:bioformats2raw:0.9.4'
     testImplementation 'info.picocli:picocli:4.7.5'
 }
 


### PR DESCRIPTION
Bumping version of ZarrReader to 0.5.2

The bioformats2raw dependency included in the build.gradle is only included as a test dependency so I don't believe this requires a version bump. Looking at the code I also don't think that dependency is actually being used for an actual test at the minute and could likely be removed completely along with the 1 test method using it.

@khaledk2, I don't believe there is any other dependencies for Bio-Fromats or Omero included here that require a version bump, is that correct?